### PR TITLE
build: fix issue with arm ci crashing on dialogs

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -62,4 +62,7 @@ RUN chmod a+x /etc/init.d/xvfb
 RUN usermod -aG sudo builduser
 RUN echo 'builduser ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers
 
+# Fix issue with arm crashing on dialogs
+RUN gdk-pixbuf-query-loaders --update-cache
+
 WORKDIR /home/builduser


### PR DESCRIPTION
This resolves the issue on our arm CI where it was crashing with the following error:
```
(electron:541): Gtk-WARNING **: 21:39:57.442: Could not load a pixbuf from 
/org/gtk/libgtk/icons/16x16/status/image-missing.png.
This may indicate that pixbuf loaders or the mime database could not be found.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error ==
NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image 
file format (gdk-pixbuf-error-quark, 3)
```