### PR TITLE
ci: add lsof for Goma support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgtk-3-0:i386 \
     libgdk-pixbuf2.0-0:i386 \
     libdbus-1-3:i386 \
+    lsof \
   && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
   && chmod +x /setup/install-build-deps.sh \
   && bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --lib32 --arm \


### PR DESCRIPTION
`lsof` is needed for the Goma client, so this PR adds it to our docker image.