### PR TITLE
chore: Add libfuse2 for cross compiling windows on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libdbus-1-3:i386 \
     lsof \
     libgbm1:i386 \
+    libfuse2 \
   && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
   && chmod +x /setup/install-build-deps.sh \
   && bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --lib32 --arm \


### PR DESCRIPTION
libfuse2  is needed for cross compiling windows on linux.