### PR TITLE
chore: add python-dbusmock for python3 instead of python2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-dbus \
     python-pip \
     python-setuptools \
+    python3-pip \
     sudo \
     vim-nox \
     wget \
@@ -48,8 +49,11 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
 # crcmod is required by gsutil, which is used for filling the gclient git cache
 RUN pip install -U crcmod
 
-# dbusmock is needed for Electron tests
+# TODO: We can remove this step once transition to using python3 to run Electron tests is complete.
 RUN pip install python-dbusmock==0.20.0
+
+# dbusmock is needed for Electron tests
+RUN pip3 install python-dbusmock==0.20.0
 
 RUN mkdir /tmp/workspace
 RUN chown builduser:builduser /tmp/workspace

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -34,6 +34,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
  nano \
  python-setuptools \
  python-pip \
+ python3-pip \
  sudo \
  unzip \
  wget \
@@ -48,8 +49,11 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
 # crcmod is required by gsutil, which is used for filling the gclient git cache
 RUN pip install -U crcmod
 
-# dbusmock is needed for Electron tests
+# TODO: We can remove this step once transition to using python3 to run Electron tests is complete.
 RUN pip install python-dbusmock==0.20.0
+
+# dbusmock is needed for Electron tests
+RUN pip3 install python-dbusmock==0.20.0
 
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -41,6 +41,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
  nano \
  python-setuptools \
  python-pip \
+ python3-pip \
  sudo \
  unzip \
  wget \
@@ -55,8 +56,11 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
 # crcmod is required by gsutil, which is used for filling the gclient git cache
 RUN pip install -U crcmod
 
-# dbusmock is needed for Electron tests
+# TODO: We can remove this step once transition to using python3 to run Electron tests is complete.
 RUN pip install python-dbusmock==0.20.0
+
+# dbusmock is needed for Electron tests
+RUN pip3 install python-dbusmock==0.20.0
 
 ADD tools/xvfb-init.sh /etc/init.d/xvfb
 RUN chmod a+x /etc/init.d/xvfb


### PR DESCRIPTION
dbusmock is required to run electron tests. Since we'd now be using
python3 to run electron tests on linux, we need to set-up
python-dbusmock module for python3. Also, the lastest working version of
python-dbusmock on ubuntu:18.04 is v0.20.0, we need to lock dbusmock to
that version.

Notes: none