### PR TITLE
fix: add libcurl4:i386 to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libdbus-1-3:i386 \
     lsof \
     libgbm1:i386 \
+    libcurl4:i386 \
     libfuse2 \
   && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
   && chmod +x /setup/install-build-deps.sh \


### PR DESCRIPTION
This is required for the crashpad tests on Linux.