### PR TITLE
chore: install the latest version of git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libgbm1:i386 \
     libcurl4:i386 \
     libfuse2 \
+    software-properties-common \
+  && add-apt-repository ppa:git-core/ppa -y && apt-get update \
   && curl https://chromium.googlesource.com/chromium/src/+/HEAD/build/install-build-deps.sh\?format\=TEXT | base64 --decode | cat > /setup/install-build-deps.sh \
   && chmod +x /setup/install-build-deps.sh \
   && bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --lib32 --arm \


### PR DESCRIPTION
We need a newer version of git installed for depot_tools/gclient sync