### PR TITLE
chore: add dbus-x11 and python3-gi on arm64

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -16,6 +16,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
  build-essential \
  clang \
  curl \
+ dbus-x11 \
  gperf \
  git \
  libasound2 \
@@ -41,6 +42,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
  nano \
  python-setuptools \
  python3-dbus \
+ python3-gi \
  python3-setuptools \
  python-pip \
  python3-pip \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -40,6 +40,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
  locales \
  nano \
  python-setuptools \
+ python3-dbus \
  python3-setuptools \
  python-pip \
  python3-pip \


### PR DESCRIPTION
dbus-x11 and python3-gi are needed for testing on arm64