### PR TITLE
ci: fixup docker push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,7 @@ jobs:
                 name: Push Docker Image
                 command: |
                   echo "$GITHUB_TOKEN" | docker login  ghcr.io -u "$GITHUB_USER" --password-stdin
-                  docker push ghcr.io/electron/<< parameters.image-name >>
-
-orbs:
-  docker: circleci/docker@0.5.17
+                  docker push ghcr.io/electron/<< parameters.image-name >>:<< parameters.tag-prefix>>latest
 
 workflows:
   version: 2.1


### PR DESCRIPTION
For some reason docker push/publish isn't working for the new arm hardware generated images.  This should fix it.