### PR TITLE
build: add desktop-file-utils

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -23,6 +23,7 @@ package_list="
     lsof \
     libfuse2 \
     software-properties-common \
+    desktop-file-utils \
     xvfb"
 
 package_list_32bit="


### PR DESCRIPTION
This is needed for the GDK_BACKEND tests added in the PR
https://github.com/electron/electron/pull/32929
Linking the CI failure for reference
https://app.circleci.com/pipelines/github/electron/electron/49609/workflows/aea05201-cf99-4043-8020-a98213a8185a/jobs/1131116