### PR TITLE
build: add arm non-runner containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
         type: boolean
       image-name:
         type: string
+      platform:
+        type: string
+        default: linux/amd64
       executor-type:
         type: executor
 
@@ -37,7 +40,7 @@ jobs:
       - run:
           name: Build Docker Image - << parameters.dockerfile >>
           command: |
-            docker build . -t electron-<< parameters.image-name >>-image -f << parameters.dockerfile >>
+            docker build --platform=<< parameters.platform >> . -t electron-<< parameters.image-name >>-image -f << parameters.dockerfile >>
             docker tag electron-<< parameters.image-name >>-image ghcr.io/electron/<< parameters.image-name >>:<< parameters.tag-prefix>>latest
             docker tag electron-<< parameters.image-name >>-image ghcr.io/electron/<< parameters.image-name >>:<< parameters.tag-prefix >>$CIRCLE_SHA1
 
@@ -113,9 +116,22 @@ workflows:
       - build-image:
           name: build-arm64v7-test
           executor-type: linux
-          dockerfile: Dockerfile.tests.arm64v8
+          dockerfile: Dockerfile.tests.arm
           tag-prefix: arm64v8-
           image-name: test
+          platform: linux/arm64
+          publish: true
+          filters:
+            branches:
+              ignore:
+                - main
+      - build-image:
+          name: build-arm64v7-test
+          executor-type: linux
+          dockerfile: Dockerfile.tests.arm
+          tag-prefix: arm32v7-
+          image-name: test
+          platform: linux/arm
           publish: true
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,30 @@ workflows:
               only:
                 - main
       - build-image:
+          name: publish-arm64v8-test
+          executor-type: linux
+          dockerfile: Dockerfile.tests.arm
+          tag-prefix: arm64v8-
+          image-name: test
+          platform: linux/arm64
+          publish: true
+          filters:
+            branches:
+              only:
+                - main
+      - build-image:
+          name: publish-arm32v7-test
+          executor-type: linux
+          dockerfile: Dockerfile.tests.arm
+          tag-prefix: arm32v7-
+          image-name: test
+          platform: linux/arm
+          publish: true
+          filters:
+            branches:
+              only:
+                - main
+      - build-image:
           name: publish-devcontainer
           executor-type: linux
           dockerfile: Dockerfile.devcontainer
@@ -114,25 +138,25 @@ workflows:
               ignore:
                 - main
       - build-image:
-          name: build-arm64v7-test
+          name: build-arm64v8-test
           executor-type: linux
           dockerfile: Dockerfile.tests.arm
           tag-prefix: arm64v8-
           image-name: test
           platform: linux/arm64
-          publish: true
+          publish: false
           filters:
             branches:
               ignore:
                 - main
       - build-image:
-          name: build-arm64v7-test
+          name: build-arm32v7-test
           executor-type: linux
           dockerfile: Dockerfile.tests.arm
           tag-prefix: arm32v7-
           image-name: test
           platform: linux/arm
-          publish: true
+          publish: false
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,10 @@ jobs:
           name: Get CircleCI runner
           command: tools/get-circleci-runner.sh
       - run:
+          name: Register QEMU
+          command: |
+            docker run --privileged --rm tonistiigi/binfmt --install all
+      - run:
           name: Build Docker Image - << parameters.dockerfile >>
           command: |
             docker build . -t electron-<< parameters.image-name >>-image -f << parameters.dockerfile >>
@@ -101,6 +105,17 @@ workflows:
           dockerfile: Dockerfile
           tag-prefix: ''
           image-name: build
+          publish: false
+          filters:
+            branches:
+              ignore:
+                - main
+      - build-image:
+          name: build-arm64v7-test
+          executor-type: linux
+          dockerfile: Dockerfile.tests.arm64v8
+          tag-prefix: arm64v8-
+          image-name: test
           publish: false
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
           dockerfile: Dockerfile.tests.arm64v8
           tag-prefix: arm64v8-
           image-name: test
-          publish: false
+          publish: true
           filters:
             branches:
               ignore:

--- a/Dockerfile.tests.arm
+++ b/Dockerfile.tests.arm
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 ubuntu:20.04
+FROM ubuntu:20.04
 
 LABEL org.opencontainers.image.source https://github.com/electron/build-images
 

--- a/Dockerfile.tests.arm64v8
+++ b/Dockerfile.tests.arm64v8
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM --platform=linux/arm64 ubuntu:20.04
 
 RUN groupadd --gid 1000 builduser \
   && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser \
@@ -10,7 +10,7 @@ RUN chmod a+rwx /tmp
 
 # Install Linux packages
 ADD tools/install-deps.sh /tmp/
-RUN bash /tmp/install-deps.sh --32bit
+RUN bash /tmp/install-deps.sh --arm
 
 # Add xvfb init script
 ADD tools/xvfb-init.sh /etc/init.d/xvfb

--- a/Dockerfile.tests.arm64v8
+++ b/Dockerfile.tests.arm64v8
@@ -1,5 +1,7 @@
 FROM --platform=linux/arm64 ubuntu:20.04
 
+LABEL org.opencontainers.image.source https://github.com/electron/build-images
+
 RUN groupadd --gid 1000 builduser \
   && useradd --uid 1000 --gid builduser --shell /bin/bash --create-home builduser \
   && mkdir -p /setup

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -49,7 +49,9 @@ package_list_arm="
     libatk-bridge2.0-0 \
     libcups2 \
     libgbm1 \
-    libgtk-3-0"
+    libgtk-3-0 \
+    make \
+    build-essential"
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list
 if [[ "$1" == "--32bit" ]]; then

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -42,9 +42,21 @@ package_list_32bit="
     libcurl4:i386 \
     libasound2:i386"
 
+package_list_arm="
+    unzip \
+    libnss3 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libgbm1 \
+    libgtk-3-0"
+
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list
 if [[ "$1" == "--32bit" ]]; then
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list_32bit
+fi
+if [[ "$1" == "--arm" ]]; then
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list_arm
 fi
     
 

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -4,7 +4,9 @@ set -e
 
 echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
 
-dpkg --add-architecture i386
+if [[ "$1" == "--32bit" ]]; then
+  dpkg --add-architecture i386
+fi
 apt-get update
 
 package_list="
@@ -41,7 +43,7 @@ package_list_32bit="
     libasound2:i386"
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list
-if [[ "$1" == "--multiarch" ]]; then
+if [[ "$1" == "--32bit" ]]; then
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $package_list_32bit
 fi
     
@@ -59,10 +61,12 @@ sed -i 's/packages.append("snapcraft")/print("skipping snapcraft")/g' /setup/ins
 chmod +x /setup/install-build-deps.sh
 chmod +x /setup/install-build-deps.py
 
-if [[ "$1" == "--multiarch" ]]; then
-  bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --lib32 --arm --no-nacl
+if [[ "$1" == "--32bit" ]]; then
+  DEBIAN_FRONTEND=noninteractive bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --lib32 --arm --no-nacl
+elif [[ "$1" == "--arm" ]]; then
+  echo Not installing Chromium deps
 else
-  bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --no-arm --no-nacl
+  DEBIAN_FRONTEND=noninteractive bash /setup/install-build-deps.sh --syms --no-prompt --no-chromeos-fonts --no-arm --no-nacl
 fi
 rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Our current arm64/32 containers have circle runners embeded within them, this adds arm64/arm32 containers without the runner that are capable of running electrons tests for use for our container infra

x64 builds are failing but they were failing before this PR so I'll fix that later separately