### PR TITLE
feat: add gdb for Codespaces debugging

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -13,6 +13,7 @@ package_list="
     ca-certificates \
     curl \
     file \
+    gdb \
     gnupg \
     libnotify-bin \
     locales \


### PR DESCRIPTION
As in title. Without this, Codespaces won't have gdb and `e debug` won't work out of the box without running `sudo apt-get update && sudo apt-get install gdb`