### PR TITLE
refactor: use nvm for Node.js installation

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -102,12 +102,10 @@ fi
 rm -rf /var/lib/apt/lists/*
 
 # Install Node.js
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-NODE_MAJOR=20
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-apt-get update
-apt-get install nodejs -y
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+nvm install 20
 
 # Install Yarn
 npm i -g yarn


### PR DESCRIPTION
https://github.com/electron/docs-parser now requires Nodejs > 20.10.0 and Nodesource doesn't seem to yet have released it. As a result, Codespaces are DOA as of now. This fixes that.

See https://app.circleci.com/pipelines/github/electron/build-images/174/workflows/65c21597-7b70-4fde-b1e4-48ba6cb239f4/jobs/686?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary for successful run:

```
=> Downloading nvm from git to '/root/.nvm'
=> Cloning into '/root/.nvm'...
* (HEAD detached at FETCH_HEAD)
  master
=> Compressing and cleaning up git repository

=> Appending nvm source string to /root/.bashrc
=> Appending bash_completion source string to /root/.bashrc
=> Close and reopen your terminal to start using nvm or run the following to use it now:

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
Downloading and installing node v20.18.0...
Downloading https://nodejs.org/dist/v20.18.0/node-v20.18.0-linux-x64.tar.xz...
######################################################################## 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v20.18.0 (npm v10.8.2)
Creating default alias: default -> 20 (-> v20.18.0 *)
USING Node.js version: v20.18.0
```