### PR TITLE
build: install Node 22 by default

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -102,7 +102,7 @@ rm -rf /var/lib/apt/lists/*
 # Install Node.js
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-NODE_MAJOR=20
+NODE_MAJOR=22
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 apt-get update
 apt-get install nodejs -y


### PR DESCRIPTION
With the merge of https://github.com/electron/electron/pull/44281, Electron now supports Node 22 by default. This PR updates our images to build with Node 22.