### PR TITLE
build: add jq on Linux

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -17,6 +17,7 @@ package_list="
     g++-10 \
     gdb \
     gnupg \
+    jq \
     libnotify-bin \
     locales \
     lsb-release \


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/46274. 

jq is already present on macOS machines.