### PR TITLE
ci: add faraday trust configuration

### DIFF
--- a/.github/faraday.yml
+++ b/.github/faraday.yml
@@ -1,0 +1,7 @@
+# faraday trust configuration for electron/build-images.
+# See: https://github.com/electron/faraday
+
+trusted-bots:
+  # Image roll PRs.
+  - login: electron-roller[bot]
+    id: 84116207


### PR DESCRIPTION
Adds the `.github/faraday.yml` trust configuration for [faraday](https://github.com/electron/faraday), the GitHub App that enforces a two-person rule on pull requests across the `electron` org starting Monday.

A bot listed in `trusted-bots` has its pull requests treated as trusted (1 maintainer approval instead of 2), provided every commit is verifiably authored, committed, and signed by the bot. A bot listed under `approvers` may stand in for a human review on PRs authored by the bot it is paired with — and only that bot.

See the [faraday README](https://github.com/electron/faraday#trusted-bots) for the full policy.
