### PR TITLE
build: pin ubuntu:22.04 base image by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 RUN groupadd --gid 999 builduser \
   && useradd --uid 999 --gid builduser --shell /bin/bash --create-home builduser \

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 RUN groupadd --gid 999 builduser \
   && useradd --uid 999 --gid builduser --shell /bin/bash --create-home builduser \

--- a/Dockerfile.tests.arm
+++ b/Dockerfile.tests.arm
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 LABEL org.opencontainers.image.source https://github.com/electron/build-images
 


### PR DESCRIPTION
Pins all three Dockerfiles to the current `ubuntu:22.04` manifest-list digest so builds are reproducible and can't silently pick up a re-tagged base.

Adds a `docker` package-ecosystem to `dependabot.yml` so the digest gets bumped automatically whenever Canonical publishes a patched 22.04 — we stay digest-pinned *and* stay current on security updates. Dependabot tracks the `22.04` tag and won't move us to a new LTS on its own.