### PR TITLE
chore: remove explicit gcc-10 and g++-10 installation

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -13,8 +13,6 @@ package_list="
     ca-certificates \
     curl \
     file \
-    gcc-10 \
-    g++-10 \
     gdb \
     gnupg \
     jq \
@@ -79,16 +77,6 @@ sed -i 's/packages.append("snapcraft")/print("skipping snapcraft")/g' /setup/ins
 # Ensure installation files are executable
 chmod +x /setup/install-build-deps.sh
 chmod +x /setup/install-build-deps.py
-
-# Ensure g++ and gcc are linked to the correct version
-current_gcc_version=$(g++ -dumpversion | cut -d. -f1)
-if [[ "$current_gcc_version" -lt 10 ]]; then
-  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
-  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-
-  sudo update-alternatives --config gcc
-  sudo update-alternatives --config g++
-fi
 
 # No Sudo Prompt
 echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser


### PR DESCRIPTION
- Removed gcc-10 and g++-10 from the package list and the version check logic for gcc and g++.  This is no longer needed after the ubuntu 22.04 upgrade (#47) as that ships with a default gcc version of 11: https://ubuntu.com/developers/docs/reference/availability/gcc/