### PR TITLE
feat: use the Azure Ubuntu mirrors and preinstall CUPS in the Linux images

### DIFF
--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -7,6 +7,15 @@ echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select tr
 if [[ "$1" == "--32bit" ]]; then
   dpkg --add-architecture i386
 fi
+
+# CI runs these images on Azure-hosted runners, where the in-region Ubuntu
+# mirrors are far faster than archive/security/ports.ubuntu.com (which have
+# been seen at ~30 kB/s from the ARC pods). They serve the same signed indices
+# and are reachable from anywhere, so use them for image builds too.
+sed -i -E \
+  -e 's#http://(archive|security)\.ubuntu\.com/ubuntu#http://azure.archive.ubuntu.com/ubuntu#g' \
+  -e 's#http://ports\.ubuntu\.com/ubuntu-ports#http://azure.ports.ubuntu.com/ubuntu-ports#g' \
+  /etc/apt/sources.list
 apt-get update
 
 package_list="
@@ -29,7 +38,10 @@ package_list="
     software-properties-common \
     desktop-file-utils \
     weston \
-    xvfb"
+    xvfb \
+    cups-daemon \
+    cups-client \
+    cups-ipp-utils"
 
 package_list_32bit="
     g++-multilib \


### PR DESCRIPTION
electron/electron's Linux test jobs spend ~20 min in "Setup CUPS virtual printer" ([example](https://github.com/electron/electron/actions/runs/33935184329/job/101223567383)): 9 min of `apt-get update` and 11 min downloading 20 MB of cups packages, because `archive.ubuntu.com`/`security.ubuntu.com` serve the Azure ARC pods at 30–115 kB/s. Everything else in that parallel group is done in ~1 min.

- Rewrite `/etc/apt/sources.list` to `azure.archive.ubuntu.com` (amd64/i386) and `azure.ports.ubuntu.com` (arm64/armhf) before the first `apt-get update`. Same signed indices, all three pockets, reachable from anywhere.
- Add `cups-daemon cups-client cups-ipp-utils` to the common package list so the CI step only needs to start `cupsd` and register the printer (~20 s).

Follow-up in electron/electron once an image with this is pinned: drop the `apt-get update/install` from the CUPS step.